### PR TITLE
Don't prepend comma to the very first argument

### DIFF
--- a/Gate.pl
+++ b/Gate.pl
@@ -231,6 +231,7 @@ BEGIN {
 
       if ($libarg eq 'first' && !$prototype->{nb}) {
           print "$sfd->{basetype} _base";
+          print $prototype->{numargs} > 0 ? ", " : "";
       }
 
       for my $i (0 .. $prototype->{numargs} - 1 ) {
@@ -245,7 +246,8 @@ BEGIN {
           $argdef =~ s/\(\*+\)/\(\*$argname\)/g;
         }
 
-        print ", $argdef";
+        print $i > 0 ? ", " : "";
+        print "$argdef";
       }
 
       if ($libarg eq 'last' && !$prototype->{nb}) {


### PR DESCRIPTION
We do not want to produce prototypes like:

struct ClassLibrary* _ClassInit(, struct ClassLibrary* ___library, BPTR ___seglist, struct ExecBase* ___SysBase); struct ClassLibrary* _ClassOpen(, ULONG ___version, struct ClassData* _base);

When for instance using --addvectors=boopsi and --libarg=last in

sfdc --gateprefix=gw --libprefix=_ --libarg=last --target=m68k-unknown-amigaos  --mode=libproto --addvectors=boopsi boopsi.sfd -o boopsi-impl.h